### PR TITLE
Give the select element a white background

### DIFF
--- a/src/css/pages/_contact.scss
+++ b/src/css/pages/_contact.scss
@@ -59,8 +59,12 @@
         align-items: center;
         justify-content: flex-end;
 
+        border-top-right-radius: 5px;
+        border-bottom-right-radius: 5px;
+        padding: 0 2rem 0 2.5rem;
         height: 100%;
-        width: 100%;
+
+        background-color: $color-black;
 
         // Allow a click on this container to open the select element
         pointer-events: none;
@@ -69,8 +73,6 @@
           content: "›";
 
           transform: rotate(90deg);
-
-          margin-right: 2rem;
 
           font-size: 4rem;
           color: $color-white;
@@ -81,29 +83,16 @@
       select {
         appearance: none;
 
-        border: none;
+        border: solid 2px $color-black;
         border-radius: 5px;
-
-        color: $color-white;
-
-        background-color: $color-black;
-
-        option {
-          color: $color-black;
-
-          background-color: $color-white;
-        }
       }
 
       // Changes the arrow direction when the select element receives focus.
       // Not ideal because it applies whenever it has focus, not just when
       // the options are open.
       select:focus + .select-arrow::after {
-        transform: rotate(-90deg);
-
-        // Needs to be changed because the rotated >
-        // is asymmetrical.
-        margin-right: 3rem;
+        //transform: rotate(-90deg);
+        content: "‹";
       }
     }
 


### PR DESCRIPTION
The select element on the contact page used to have a black background, but it should actually have a white background. The arrow should still have a black background.
 
This PR fixes the style.